### PR TITLE
HTML rewriting: Don't escape script tag contents

### DIFF
--- a/kubewebproxy.go
+++ b/kubewebproxy.go
@@ -306,7 +306,15 @@ func rewriteRelativeLinks(w io.Writer, r io.Reader, rootPath string, relativePat
 			}
 		}
 
-		_, err := w.Write([]byte(t.String()))
+		// t.String() incorrectly escapes <script> content
+		// https://github.com/golang/go/issues/7929
+		var content string
+		if tokenType == html.TextToken {
+			content = t.Data
+		} else {
+			content = t.String()
+		}
+		_, err := w.Write([]byte(content))
 		if err != nil {
 			return err
 		}

--- a/kubewebproxy_test.go
+++ b/kubewebproxy_test.go
@@ -189,6 +189,8 @@ func TestRewriteHTML(t *testing.T) {
 		`"https://www.example.com/absolute"`,
 		`"/extra/path/rootrelative"`,
 		`"/extra/path/subdir/dir/relative1"`,
+		// Checks for https://github.com/golang/go/issues/7929
+		`"use strict";`,
 	}
 	for i, s := range mustContain {
 		if !strings.Contains(out.String(), s) {
@@ -213,4 +215,12 @@ func TestHealth(t *testing.T) {
 const exampleHTML = `<html><body>
 <a href="./dir/relative1">relative1</a>
 <a href="/rootrelative">rootrelative</a>
-<a href="https://www.example.com/absolute">absolute</a></body></html>`
+<a href="https://www.example.com/absolute">absolute</a>
+<form method="post" action="/root/post">
+<script>
+function initPanAndZoom(svg, clickHandler) {
+	// x/net/html has a bug when printing scripts: https://github.com/golang/go/issues/7929
+  "use strict";
+}
+</script>
+</body></html>`


### PR DESCRIPTION
Workaround for https://github.com/golang/go/issues/7929