### PR TITLE
Allow all methods now that we require authentication

### DIFF
--- a/kubewebproxy.go
+++ b/kubewebproxy.go
@@ -158,10 +158,6 @@ func (s *server) rootHandler(w http.ResponseWriter, r *http.Request) {
 // proxies a request
 func (s *server) proxyErrWrapper(w http.ResponseWriter, r *http.Request) {
 	log.Printf("proxy %s %s", r.Method, r.URL.String())
-	if r.Method != http.MethodGet {
-		http.Error(w, "wrong method", http.StatusMethodNotAllowed)
-		return
-	}
 	err := s.proxy(w, r)
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
One theory was this proxy should only allow GET, so it can't be used
to modify stuff. However, if it is now authenicated, POST is useful?