### PR TITLE
Only rewrite absolute paths starting with /

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Since this is a potential security hole, Kube Web Proxy requires requests to hav
 
 ## Limitations
 
-The proxy has to rewrite paths, in order to add the namespace/service/port to the URL path. I have only used a few tiny web applications, so I'm certainly missing some rewrites that are required. This also means JavaScript that embeds paths will probably break. The solution is probably to rewrite the application to use relative paths. A better solution would be to use a wildcard domain, but that is not supported by Google's managed TLS certificates.
+The proxy has to rewrite paths, in order to add `/namespace/service/port` to the URL path. I have only used a few tiny web applications, so I'm certainly missing some rewrites that are required. Cookies will be shared between all services (TODO: rewrite the header to scope them to paths). This also means JavaScript that embeds paths will probably break. The solution is probably to rewrite the application to use relative paths. A better solution would be to use a wildcard domain, but that is not supported by Google's managed TLS certificates.
 
 
 ## Useful Documentation

--- a/kubewebproxy-deploy.yaml
+++ b/kubewebproxy-deploy.yaml
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: kubewebproxy
       containers:
       - name: kubewebproxy
-        image: us.gcr.io/gosignin-demo/kubewebproxy:debug15
+        image: us.gcr.io/gosignin-demo/kubewebproxy:debug16
         args: ["--iapAudience=/projects/660565085864/global/backendServices/5821046762714885080"]
 
         # necessary since / requires IAP authentication

--- a/kubewebproxy_test.go
+++ b/kubewebproxy_test.go
@@ -131,7 +131,7 @@ func TestProxy(t *testing.T) {
 		t.Errorf("output should contain %#v", expected)
 		t.Error(recorder.Body.String())
 	}
-	expected = fmt.Sprintf(`"%ssubdir/dir/relative1"`, goodRoot)
+	expected = `"./dir/relative1"`
 	if !strings.Contains(recorder.Body.String(), expected) {
 		t.Errorf("output should contain %#v", expected)
 		t.Error(recorder.Body.String())
@@ -175,7 +175,6 @@ func TestPathRegexp(t *testing.T) {
 
 func TestRewriteURL(t *testing.T) {
 	const rootPath = "/extra/path"
-	const relativePath = "/subdir/"
 	type testData struct {
 		input    string
 		expected string
@@ -184,23 +183,23 @@ func TestRewriteURL(t *testing.T) {
 		{"https://www.example.com/path", "https://www.example.com/path"},
 		{"/root", "/extra/path/root"},
 		{"/root/", "/extra/path/root/"},
-		{"./dir/relative", "/extra/path/subdir/dir/relative"},
-		{"./dir/relative/", "/extra/path/subdir/dir/relative/"},
-		{"relative.txt", "/extra/path/subdir/relative.txt"},
+		{"./dir/relative", "./dir/relative"},
+		{"./dir/relative/", "./dir/relative/"},
+		{"relative.txt", "relative.txt"},
 		{"#anchor", "#anchor"},
 	}
 	for i, test := range tests {
-		output := rewriteURL(test.input, rootPath, relativePath)
+		output := rewriteURL(test.input, rootPath)
 		if output != test.expected {
-			t.Errorf("%d: rewriteURL(%#v, %#v, %#v)=%#v; expected %#v",
-				i, test.input, rootPath, relativePath, output, test.expected)
+			t.Errorf("%d: rewriteURL(%#v, %#v)=%#v; expected %#v",
+				i, test.input, rootPath, output, test.expected)
 		}
 	}
 }
 
 func TestRewriteHTML(t *testing.T) {
 	out := &bytes.Buffer{}
-	err := rewriteRelativeLinks(out, strings.NewReader(exampleHTML), "/extra/path", "/subdir")
+	err := rewriteAbsolutePathLinks(out, strings.NewReader(exampleHTML), "/extra/path")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +207,7 @@ func TestRewriteHTML(t *testing.T) {
 	mustContain := []string{
 		`"https://www.example.com/absolute"`,
 		`"/extra/path/rootrelative"`,
-		`"/extra/path/subdir/dir/relative1"`,
+		`"./dir/relative1"`,
 		`"/extra/path/root/post"`,
 		// Checks for https://github.com/golang/go/issues/7929
 		`"use strict";`,


### PR DESCRIPTION
I'm not sure why I thought I needed to rewrite relative paths as well.
We don't need to, so don't do it. Makes it simpler.